### PR TITLE
#13 Fixed togglz dependency issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <isis-module-security.version>1.13.0</isis-module-security.version>
         <isis-module-sessionlogger.version>1.13.0</isis-module-sessionlogger.version>
         <isis-module-settings.version>1.13.0</isis-module-settings.version>
-        <isis-module-togglz.version>1.13.0</isis-module-togglz.version>
+        <isis-module-togglz.version>1.13.1</isis-module-togglz.version>
 
         <isis-module-docx.version>1.13.0</isis-module-docx.version>
 


### PR DESCRIPTION
Both `mvn clean install` and `mvn jetty:run -D jetty.port=9090` seem to work fine now.
